### PR TITLE
Add basic working prototype of command to watch targets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,14 @@ provided during ``add``.
 
     $ s4 sync myfolder1
 
+
+If you wish to synchronise your targets continiously, use the ``daemon`` command:
+
+::
+
+    $ s4 daemon myfolder1
+
+
 Handling Conflicts
 ------------------
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,5 @@ mock==2.0.0
 moto==0.4.30
 pytest==3.0.2
 pytest-cov==2.4.0
+pytest-timeout==1.2.0
 pytz==2016.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tabulate>=0.7.7
 tqdm>=4.8.4
 scandir>=1.5
 inotify-simple>=1.1.0
+enum34>=1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-magic>=0.4.12
 tabulate>=0.7.7
 tqdm>=4.8.4
 scandir>=1.5
+inotify-simple>=1.1.0

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -61,6 +61,11 @@ def main(arguments):
         default='INFO',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
     )
+    parser.add_argument(
+        '--timestamps',
+        action='store_true',
+        help='Display timestamps for each log message',
+    )
     subparsers = parser.add_subparsers(dest='command')
 
     daemon_parser = subparsers.add_parser('daemon', help="Run S4 continiously")
@@ -101,6 +106,9 @@ def main(arguments):
         log_format = '%(levelname)s:%(module)s:%(lineno)s %(message)s'
     else:
         log_format = '%(message)s'
+
+    if args.timestamps:
+        log_format = '%(asctime)s: ' + log_format
 
     logging.basicConfig(format=log_format, level=args.log_level)
 

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -59,6 +59,7 @@ def main(arguments):
 
     daemon_parser = subparsers.add_parser('daemon', help="Run S4 continiously")
     daemon_parser.add_argument('targets', nargs='*')
+    daemon_parser.add_argument('--read-delay', default=1000, type=int)
 
     subparsers.add_parser('add', help="Add a new Target to synchronise")
 
@@ -195,7 +196,7 @@ def daemon_command(args, config, logger):
 
     while True:
         to_run = set()
-        for event in notifier.read(read_delay=1000):
+        for event in notifier.read(read_delay=args.read_delay):
             print(event)
             # Dont bother running for .index
             if event.name != '.index':

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -217,6 +217,11 @@ def sync_command(args, config, logger):
 
     try:
         for name in sorted(targets):
+            keys = None
+            if ':' in name:
+                name, key = name.split(':')
+                keys = [key]
+
             if name not in config['targets']:
                 logger.info('"%s" is an unknown target. Choices are: %s', name, all_targets)
                 continue
@@ -228,7 +233,7 @@ def sync_command(args, config, logger):
                 worker = sync.SyncWorker(client_1, client_2)
 
                 logger.info('Syncing %s [%s <=> %s]', name, client_1.get_uri(), client_2.get_uri())
-                worker.sync(conflict_choice=args.conflicts)
+                worker.sync(conflict_choice=args.conflicts, keys=keys)
             except Exception as e:
                 logger.error("There was an error syncing '%s': %s", name, e)
     except KeyboardInterrupt:

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -60,6 +60,7 @@ def main(arguments):
     daemon_parser = subparsers.add_parser('daemon', help="Run S4 continiously")
     daemon_parser.add_argument('targets', nargs='*')
     daemon_parser.add_argument('--read-delay', default=1000, type=int)
+    daemon_parser.add_argument('--conflicts', default='ignore', choices=['1', '2', 'ignore'])
 
     subparsers.add_parser('add', help="Add a new Target to synchronise")
 
@@ -192,7 +193,7 @@ def daemon_command(args, config, logger):
 
         # Check for any pending changes
         worker = get_sync_worker(entry)
-        worker.sync(conflict_choice='ignore')
+        worker.sync(conflict_choice=args.conflicts)
 
     while True:
         to_run = set()
@@ -205,7 +206,7 @@ def daemon_command(args, config, logger):
         for wd in to_run:
             entry = watch_map[event.wd]
             worker = get_sync_worker(entry)
-            worker.sync(conflict_choice='ignore')
+            worker.sync(conflict_choice=args.conflicts)
 
 
 def sync_command(args, config, logger):

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -248,11 +248,6 @@ def sync_command(args, config, logger):
 
     try:
         for name in sorted(targets):
-            keys = None
-            if ':' in name:
-                name, key = name.split(':')
-                keys = [key]
-
             if name not in config['targets']:
                 logger.info('"%s" is an unknown target. Choices are: %s', name, all_targets)
                 continue
@@ -264,7 +259,7 @@ def sync_command(args, config, logger):
                 worker = sync.SyncWorker(client_1, client_2)
 
                 logger.info('Syncing %s [%s <=> %s]', name, client_1.get_uri(), client_2.get_uri())
-                worker.sync(conflict_choice=args.conflicts, keys=keys)
+                worker.sync(conflict_choice=args.conflicts)
             except Exception as e:
                 logger.error("There was an error syncing '%s': %s", name, e)
     except KeyboardInterrupt:

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -68,7 +68,7 @@ def main(arguments):
     )
     subparsers = parser.add_subparsers(dest='command')
 
-    daemon_parser = subparsers.add_parser('daemon', help="Run S4 continiously")
+    daemon_parser = subparsers.add_parser('daemon', help="Run S4 sync continiously")
     daemon_parser.add_argument('targets', nargs='*')
     daemon_parser.add_argument('--read-delay', default=1000, type=int)
     daemon_parser.add_argument('--conflicts', default='ignore', choices=['1', '2', 'ignore'])

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -194,8 +194,14 @@ def daemon_command(args, config, logger):
         worker.sync(conflict_choice='ignore')
 
     while True:
-        for event in notifier.read():
+        to_run = set()
+        for event in notifier.read(read_delay=1000):
             print(event)
+            # Dont bother running for .index
+            if event.name != '.index':
+                to_run.add(event.wd)
+
+        for wd in to_run:
             entry = watch_map[event.wd]
             worker = get_sync_worker(entry)
             worker.sync(conflict_choice='ignore')

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -223,9 +223,9 @@ def sync_command(args, config, logger):
             entry = config['targets'][name]
             client_1, client_2 = get_clients(entry)
 
-            worker = sync.SyncWorker(client_1, client_2)
-
             try:
+                worker = sync.SyncWorker(client_1, client_2)
+
                 logger.info('Syncing %s [%s <=> %s]', name, client_1.get_uri(), client_2.get_uri())
                 worker.sync(conflict_choice=args.conflicts)
             except Exception as e:

--- a/s4/sync.py
+++ b/s4/sync.py
@@ -88,6 +88,9 @@ class SyncWorker(object):
         self.client_2 = client_2
         self.logger = logging.getLogger(str(self))
 
+    def __repr__(self):
+        return 'SyncWorker<{}, {}>'.format(self.client_1.get_uri(), self.client_2.get_uri())
+
     def sync(self, conflict_choice=None, keys=None):
         try:
             deferred_calls, unhandled_events = self.get_sync_states(keys)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ def get_timestamp(year, month, day, hour, minute):
 
 
 class TestINotifyRecursive(object):
+    @pytest.mark.timeout(5)
     def test_add_watches(self, tmpdir):
         foo = tmpdir.mkdir("foo")
         bar = tmpdir.mkdir("bar")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,18 @@ class TestMain(object):
         cli.main([])
         assert print_help.call_count == 1
 
+    @pytest.mark.parametrize(['loglevel'], [('INFO', ), ('DEBUG', )])
+    @mock.patch('logging.basicConfig')
+    def test_timestamps(self, basicConfig, loglevel):
+        cli.main(['--timestamps', '--log-level', loglevel, 'version'])
+        assert basicConfig.call_args[1]['format'].startswith('%(asctime)s: ')
+
+    @mock.patch('logging.basicConfig')
+    def test_debug_loglevel(self, basicConfig):
+        cli.main(['--log-level=DEBUG', 'version'])
+        assert basicConfig.call_args[1]['format'].startswith('%(levelname)s:%(module)s')
+        assert basicConfig.call_args[1]['level'] == 'DEBUG'
+
     def test_version_command(self, capsys):
         cli.main(['version'])
         out, err = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 from datetime import datetime
 
-from inotify_simple import flags
+from inotify_simple import flags, Event
 import mock
 import pytest
 import pytz
@@ -162,6 +162,80 @@ class TestGetConfigFile(object):
             json.dump({'local_folder': '/home/someone/something'}, fp)
 
         assert cli.get_config() == {'local_folder': '/home/someone/something'}
+
+
+class FakeINotify(object):
+    def __init__(self, events, wd_map):
+        self.events = events
+        self.wd_map = wd_map
+
+    def add_watches(self, *args, **kwargs):
+        return self.wd_map
+
+    def read(self, *args, **kwargs):
+        return self.events
+
+
+@mock.patch('s4.sync.SyncWorker')
+@mock.patch('s4.cli.INotifyRecursive')
+class TestDaemonCommand(object):
+    def single_term(self, index):
+        """Simple terminator for the daemon command"""
+        return index >= 1
+
+    @pytest.mark.timeout(5)
+    def test_no_targets(self, INotifyRecursive, SyncWorker, logger):
+        args = argparse.Namespace(targets=None, conflicts='ignore', read_delay=0)
+        cli.daemon_command(args, {'targets': {}}, logger, terminator=self.single_term)
+
+        assert get_stream_value(logger) == (
+            'No targets available\n'
+            'Use "add" command first\n'
+        )
+        assert SyncWorker.call_count == 0
+        assert INotifyRecursive.call_count == 0
+
+    @pytest.mark.timeout(5)
+    def test_wrong_target(self, INotifyRecursive, SyncWorker, logger):
+        args = argparse.Namespace(targets=['foo'], conflicts='ignore', read_delay=0)
+        cli.daemon_command(args, {'targets': {'bar': {}}}, logger, terminator=self.single_term)
+
+        assert get_stream_value(logger) == (
+            'Unknown target: foo\n'
+        )
+        assert SyncWorker.call_count == 0
+        assert INotifyRecursive.call_count == 0
+
+    @pytest.mark.timeout(5)
+    def test_specific_target(self, INotifyRecursive, SyncWorker, logger):
+        INotifyRecursive.return_value = FakeINotify(
+            events={
+                Event(wd=1, mask=flags.CREATE, cookie=None, name="hello.txt"),
+                Event(wd=2, mask=flags.CREATE, cookie=None, name="bar.txt"),
+            },
+            wd_map={
+                1: '/home/jon/code/',
+                2: '/home/jon/code/hoot',
+            }
+        )
+
+        args = argparse.Namespace(targets=['foo'], conflicts='ignore', read_delay=0)
+        config = {
+            'targets': {
+                'foo': {
+                    'local_folder': '/home/jon/code',
+                    's3_uri': 's3://bucket/code',
+                    'aws_secret_access_key': '23232323',
+                    'aws_access_key_id': '########',
+                    'region_name': 'eu-west-2',
+                },
+                'bar': {},
+            }
+        }
+        cli.daemon_command(args, config, logger, terminator=self.single_term)
+
+        assert SyncWorker.call_count == 2
+        assert INotifyRecursive.call_count == 1
 
 
 @mock.patch('s4.sync.SyncWorker')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,11 @@ class TestMain(object):
         cli.main(['ls', 'foo'])
         assert ls_command.call_count == 1
 
+    @mock.patch('s4.cli.daemon_command')
+    def test_daemon_command(self, daemon_command):
+        cli.main(['daemon'])
+        assert daemon_command.call_count == 1
+
     @mock.patch('s4.cli.sync_command')
     def test_sync_command(self, sync_command):
         cli.main(['sync', 'foo'])

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,7 @@ import mock
 import pytest
 
 from s4 import sync
-from s4.clients import SyncState
+from s4.clients import SyncState, local, s3
 from tests import utils
 
 
@@ -279,6 +279,12 @@ class TestShowDiff(object):
 
 
 class TestSyncWorker(object):
+    def test_repr(self):
+        local_client = local.LocalSyncClient('/home/bobs/burgers')
+        s3_client = s3.S3SyncClient(None, 'burgerbucket', 'foozie')
+        worker = sync.SyncWorker(local_client, s3_client)
+        assert repr(worker) == 'SyncWorker</home/bobs/burgers/, s3://burgerbucket/foozie/>'
+
     def test_get_deferred_function_unknown(self, local_client, s3_client):
         worker = sync.SyncWorker(local_client, s3_client)
 


### PR DESCRIPTION
# Required

- [x] Recursive watching
- [x] Only run once per group of events
- [x] timestamps in logs
- [x] Maintain test coverage

Second step requires adding a timer that periodically checks if items on S3 have changed.

# Things to Consider
- [ ] What to do if a write occurs while syncing is being performed
- [ ] What if a file was deleted after the actions were listed but before the action is run?

# Optional
- [ ] Allow synchronizing on specific keys
- [ ] Dont allow sync on ignored files
- [ ] Keep index loaded in memory for better performance
- [ ] Allow throttling on specific files which are commonly written (example `zsh_history`)
- [ ] Throttling

Fixes #38 