### PR TITLE
Target locking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3>=1.4.0
 clint>=0.5.1
+filelock>=2.0.12
 python-magic>=0.4.12
 tabulate>=0.7.7
 tqdm>=4.8.4

--- a/s4/cli.py
+++ b/s4/cli.py
@@ -117,6 +117,7 @@ def main(arguments):
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
     logging.getLogger('nose').setLevel(logging.CRITICAL)
     logging.getLogger('s3transfer').setLevel(logging.CRITICAL)
+    logging.getLogger('filelock').setLevel(logging.CRITICAL)
 
     logger = logging.getLogger(__name__)
     logger.setLevel(args.log_level)

--- a/s4/clients/__init__.py
+++ b/s4/clients/__init__.py
@@ -84,6 +84,12 @@ class SyncClient(object):
     def get_uri(self, key=''):
         raise NotImplementedError()
 
+    def lock(self, timeout=10):
+        raise NotImplementedError()
+
+    def unlock(self):
+        raise NotImplementedError()
+
     def put(self, key, sync_object):
         raise NotImplementedError()
 

--- a/s4/clients/local.py
+++ b/s4/clients/local.py
@@ -52,12 +52,12 @@ class LocalSyncClient(SyncClient):
         self.reload_ignore_files()
         self._lock = filelock.FileLock(self.get_uri('.s4lock'))
 
-    def lock(self):
+    def lock(self, timeout=10):
         """
         Advisory lock.
         Use to ensure that only one LocalSyncClient is working on the Target at the same time.
         """
-        self._lock.acquire(timeout=10)
+        self._lock.acquire(timeout=timeout)
 
     def unlock(self):
         """

--- a/s4/clients/s3.py
+++ b/s4/clients/s3.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import collections
+import copy
 import fnmatch
 import json
 import logging
@@ -44,6 +45,8 @@ def is_ignored_key(key, ignore_files):
 
 
 class S3SyncClient(SyncClient):
+    DEFAULT_IGNORE_FILES = ['.index', '.s4lock']
+
     def __init__(self, boto, bucket, prefix):
         self.boto = boto
         self.bucket = bucket
@@ -51,6 +54,12 @@ class S3SyncClient(SyncClient):
         # These are lazy loaded as needed
         self._index = None
         self._ignore_files = None
+
+    def lock(self):
+        pass
+
+    def unlock(self):
+        pass
 
     def get_client_name(self):
         return 's3'
@@ -222,7 +231,7 @@ class S3SyncClient(SyncClient):
         return self._ignore_files
 
     def reload_ignore_files(self):
-        self._ignore_files = ['.index']
+        self._ignore_files = copy.copy(self.DEFAULT_IGNORE_FILES)
         try:
             response = self.boto.get_object(
                 Bucket=self.bucket,

--- a/tests/clients/test_clients.py
+++ b/tests/clients/test_clients.py
@@ -39,6 +39,16 @@ class TestSyncState(object):
 
 
 class TestSyncClient(object):
+    def test_lock(self):
+        client = SyncClient()
+        with pytest.raises(NotImplementedError):
+            client.lock()
+
+    def test_unlock(self):
+        client = SyncClient()
+        with pytest.raises(NotImplementedError):
+            client.unlock()
+
     def test_get_client_name(self):
         client = SyncClient()
         with pytest.raises(NotImplementedError):

--- a/tests/clients/test_local.py
+++ b/tests/clients/test_local.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import tempfile
 
+import filelock
 import mock
 import pytest
 
@@ -62,8 +63,14 @@ class TestLocalSyncClient(object):
         assert repr(client) == 'LocalSyncClient</my/test/path>'
 
     def test_lock(self, local_client):
-        local_client.lock()
+        local_client2 = local.LocalSyncClient(local_client.path)
+        local_client.lock(timeout=0.01)
+        with pytest.raises(filelock.Timeout):
+            local_client2.lock(timeout=0.01)
         local_client.unlock()
+
+        local_client.lock(timeout=0.01)
+        local_client2.unlock()
 
     def test_put_new(self, local_client):
         data = b'hi'

--- a/tests/clients/test_local.py
+++ b/tests/clients/test_local.py
@@ -61,6 +61,10 @@ class TestLocalSyncClient(object):
         client = local.LocalSyncClient('/my/test/path')
         assert repr(client) == 'LocalSyncClient</my/test/path>'
 
+    def test_lock(self, local_client):
+        local_client.lock()
+        local_client.unlock()
+
     def test_put_new(self, local_client):
         data = b'hi'
         local_client.put(


### PR DESCRIPTION
Ensure that only one SyncClient is working on a target directory at the same time. This PR only includes the implementation for locking the LocalSyncClient. 

It is possible to lock the s3 directory to prevent multiple syncs from ocurring at the same time with an implementation using simple db: https://stackoverflow.com/questions/3431418/locking-with-s3#3434952