### PR TITLE
Disable travis parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 sudo: false
 language: python
-python:
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
-install: pip install tox-travis codecov
+cache: pip
+
+install:
+  - pip install tox codecov
 script:
   - tox
   - pip install . && s4 version
 after_success:
   - codecov
-cache: pip


### PR DESCRIPTION
This is actually faster than setting up and running multiple travis machines