### PR TITLE
Add --no-colors option

### DIFF
--- a/s4/cli.py
+++ b/s4/cli.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 import boto3
 
-from clint.textui import colored
+from clint.textui.colored import ColoredString
 
 from inotify_simple import INotify, flags
 
@@ -145,6 +145,11 @@ def main(arguments):
         '--log-level',
         default='INFO',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+    )
+    parser.add_argument(
+        '--no-colors',
+        action='store_true',
+        help='Display without colors',
     )
     parser.add_argument(
         '--timestamps',
@@ -390,24 +395,27 @@ def sync_command(args, config, logger):
     def action_callback(resolution):
         if resolution.action == Resolution.UPDATE:
             logger.info(
-                colored.yellow('Updating %s (%s => %s)'),
+                _colored('YELLOW', 'Updating %s (%s => %s)'),
                 resolution.key,
                 resolution.from_client.get_uri(),
                 resolution.to_client.get_uri()
             )
         elif resolution.action == Resolution.CREATE:
             logger.info(
-                colored.green('Creating %s (%s => %s)'),
+                _colored('GREEN', 'Creating %s (%s => %s)'),
                 resolution.key,
                 resolution.from_client.get_uri(),
                 resolution.to_client.get_uri()
             )
         elif resolution.action == Resolution.DELETE:
             logger.info(
-                colored.red('Deleting %s on %s'),
+                _colored('RED', 'Deleting %s on %s'),
                 resolution.key,
                 resolution.to_client.get_uri()
             )
+
+    def _colored(color, text):
+        return text if args.no_colors else ColoredString(color, text)
 
     try:
         for name in sorted(targets):


### PR DESCRIPTION
It was easier to put the `_colored` function inside. If you're not fan, I can extract it but it will have to take another argument.

Also, having `_colored('green', 'ze text')` was easy to make, compared to `_colored.green('ze text')`

Issue: https://github.com/MichaelAquilina/S4/issues/64