### PR TITLE
Add support to specify a state folder and a conflict resolution for a target

### DIFF
--- a/s4/clients/local.py
+++ b/s4/clients/local.py
@@ -17,8 +17,8 @@ from s4.clients import SyncClient, SyncObject
 logger = logging.getLogger(__name__)
 
 
-def get_local_client(target):
-    return LocalSyncClient(target)
+def get_local_client(target, state_folder):
+    return LocalSyncClient(target, state_folder)
 
 
 def traverse(path, ignore_files=None):
@@ -47,7 +47,8 @@ class LocalSyncClient(SyncClient):
     DEFAULT_IGNORE_FILES = [".index", ".s4lock"]
     LOCK_FILE_NAME = ".s4lock"
 
-    def __init__(self, path):
+    def __init__(self, path, state_folder):
+        self.state_folder = state_folder
         self.path = path
         self.reload_index()
         self.reload_ignore_files()
@@ -55,7 +56,7 @@ class LocalSyncClient(SyncClient):
 
     @property
     def lock_file(self):
-        return self.get_uri(self.LOCK_FILE_NAME)
+        return os.path.join(self.state_folder, self.LOCK_FILE_NAME)
 
     def ensure_path(self, path):
         parent = os.path.dirname(path)
@@ -95,7 +96,7 @@ class LocalSyncClient(SyncClient):
         return os.path.join(self.path, key)
 
     def index_path(self):
-        return os.path.join(self.path, ".index")
+        return os.path.join(self.state_folder, ".index")
 
     def put(self, key, sync_object, callback=None):
         path = os.path.join(self.path, key)

--- a/s4/commands/__init__.py
+++ b/s4/commands/__init__.py
@@ -18,11 +18,13 @@ class Command(object):
 
     def get_clients(self, entry):
         target_1 = entry["local_folder"]
+        target_1_state = entry.get("state_folder", target_1)
         target_2 = entry["s3_uri"]
         aws_access_key_id = entry["aws_access_key_id"]
         aws_secret_access_key = entry["aws_secret_access_key"]
         endpoint_url = entry.get("endpoint_url", None)
         region_name = entry["region_name"]
+        conflicts = entry.get("conflicts", None)
 
         # append trailing slashes to prevent incorrect prefix matching on s3
         if not target_1.endswith("/"):
@@ -30,7 +32,7 @@ class Command(object):
         if not target_2.endswith("/"):
             target_2 += "/"
 
-        client_1 = get_local_client(target_1)
+        client_1 = get_local_client(target_1, target_1_state)
         client_2 = get_s3_client(
             target_2,
             aws_access_key_id,

--- a/s4/commands/add_command.py
+++ b/s4/commands/add_command.py
@@ -37,6 +37,12 @@ class AddCommand(Command):
         region_name = utils.get_input(
             "region name [leave blank if unknown]: ", blank=True
         )
+        state_folder = utils.get_input(
+            "state folder [leave blank for target folder]: ", blank=True
+        )
+        conflicts = utils.get_input(
+            "conflicts [1 for local, 2 for s3, ignore or leave blank for default handling]: ", blank=True, regex='1|2|ignore'
+        )
 
         if aws_access_key_id is None:
             aws_access_key_id = utils.get_input(
@@ -61,9 +67,11 @@ class AddCommand(Command):
 
         self.config["targets"][name] = {
             "local_folder": local_folder,
+            "state_folder": state_folder,
             "endpoint_url": endpoint_url,
             "s3_uri": "s3://{}/{}".format(bucket, path),
             "region_name": region_name,
+            "conflicts": conflicts,
             "aws_access_key_id": aws_access_key_id,
             "aws_secret_access_key": aws_secret_access_key,
         }

--- a/s4/commands/daemon_command.py
+++ b/s4/commands/daemon_command.py
@@ -52,7 +52,7 @@ class DaemonCommand(Command):
 
             # Check for any pending changes
             worker = self.get_sync_worker(target)
-            worker.sync(conflict_choice=self.args.conflicts)
+            worker.sync(conflict_choice=self.args.conflicts if self.args.conflicts else entry.get("conflicts", "ignore"))
 
         index = 0
         while not terminator(index):

--- a/s4/commands/edit_command.py
+++ b/s4/commands/edit_command.py
@@ -26,6 +26,8 @@ class EditCommand(Command):
         aws_access_key_id = entry.get("aws_access_key_id")
         aws_secret_access_key = entry.get("aws_secret_access_key")
         region_name = entry.get("region_name")
+        state_folder = entry.get("state_folder")
+        conflicts = entry.get("conflicts", None)
 
         new_local_folder = utils.get_input("local folder [{}]: ".format(local_folder))
         new_endpoint_url = utils.get_input("endpoint url [{}]: ".format(endpoint_url))
@@ -38,6 +40,8 @@ class EditCommand(Command):
         new_aws_secret_access_key = utils.get_input(secret_key_prompt, secret=True)
 
         new_region_name = utils.get_input("region name [{}]: ".format(region_name))
+        new_state_folder = utils.get_input("state folder [{}]: ".format(state_folder))
+        new_conflicts = utils.get_input("conflicts [{}]: ".format(conflicts), regex='1|2|ignore')
 
         if new_local_folder:
             entry["local_folder"] = os.path.expanduser(new_local_folder)
@@ -51,6 +55,10 @@ class EditCommand(Command):
             entry["endpoint_url"] = new_endpoint_url
         if new_region_name:
             entry["region_name"] = new_region_name
+        if new_state_folder:
+            entry["state_folder"] = new_state_folder
+        if new_conflicts:
+            entry["conflicts"] = new_conflicts
 
         self.config["targets"][self.args.target] = entry
 

--- a/s4/commands/sync_command.py
+++ b/s4/commands/sync_command.py
@@ -102,7 +102,7 @@ class SyncCommand(Command):
                         client_2.get_uri(),
                     )
                     worker.sync(
-                        conflict_choice=self.args.conflicts, dry_run=self.args.dry_run
+                        conflict_choice=self.args.conflicts if self.args.conflicts else entry.get("conflicts", "ignore"), dry_run=self.args.dry_run
                     )
                 except Exception as e:
                     if self.args.log_level == "DEBUG":

--- a/s4/sync.py
+++ b/s4/sync.py
@@ -55,7 +55,7 @@ class SyncWorker(object):
                     resolutions[key] = Resolution.get_resolution(
                         key, action_2, self.client_1, self.client_2
                     )
-                if self.conflict_handler is not None:
+                elif self.conflict_handler is not None:
                     resolution = self.conflict_handler(
                         key, action_1, self.client_1, action_2, self.client_2
                     )

--- a/s4/utils.py
+++ b/s4/utils.py
@@ -5,6 +5,7 @@ import getpass
 import gzip
 import json
 import os
+import re
 import zlib
 
 CONFIG_FOLDER_PATH = os.path.expanduser("~/.config/s4")
@@ -30,7 +31,7 @@ def to_timestamp(dt):
     return (dt - epoch) / datetime.timedelta(seconds=1)
 
 
-def get_input(*args, secret=False, required=False, blank=False, **kwargs):
+def get_input(*args, secret=False, required=False, blank=False, regex=None, **kwargs):
     """
     secret: Don't show user input when they are typing.
     required: Keep prompting if the user enters an empty value.
@@ -45,6 +46,9 @@ def get_input(*args, secret=False, required=False, blank=False, **kwargs):
 
         if blank:
             value = value if value else None
+
+        if value and not regex == None and not re.fullmatch(regex, value):
+            continue
 
         if not required or value:
             break


### PR DESCRIPTION
New version of https://github.com/MichaelAquilina/S4/pull/184

My goal in adding this functionality is to enable syncing from a read only nfs share while keeping the files updated during our migration.

two new config options have been added:

state_folder, which is the dir to store the index and lock files
conflicts, which is a configurable version of the cli flag